### PR TITLE
使用正则表达式重构替换功能

### DIFF
--- a/src/mommy.js
+++ b/src/mommy.js
@@ -1,7 +1,8 @@
 var Mommifier = {
 	"VOWELS": "aeiou",
 	"REPLACEMENT": "mommy",
-	"THRESHOLD": 0.30
+	"THRESHOLD": 0.30,
+    "REPLACE_REG": /[aeiou]+/g
 }
 
 function isVowel(character) {
@@ -20,7 +21,7 @@ function countVowels(word) {
 	return count;
 }
 
-function next(current, previous) {
+/*function next(current, previous) {
 	var next = "";
 
 	if(isVowel(current)) {
@@ -32,16 +33,19 @@ function next(current, previous) {
 	}
 
 	return next;
-}
+}*/
 
 function replace(word) {
-	var str = "";
+	/*var str = "";
 
 	for(var i = 0; i < word.length; i++) {
 		str += next(word[i], word[i-1]);
 	}
 
-	return str;
+	return str;*/
+    
+    
+    return word.replace(Mommifier.REPLACE_REG, Mommifier.REPLACEMENT);
 }
 
 function shouldBeMommify(word) {


### PR DESCRIPTION
替换功能中的next方法有点令人费解，使用正则方式应该会使思路更清晰，性能上也更好
